### PR TITLE
Remove reserved keyword void

### DIFF
--- a/classes/report/fields/spec/event/blank.php
+++ b/classes/report/fields/spec/event/blank.php
@@ -10,7 +10,7 @@ use
 	mageekguy\atoum\exceptions
 ;
 
-class void extends report\fields\spec\event
+class blank extends report\fields\spec\event
 {
 
 	public function __construct(colorizer $colorizer = null, $detailColorizer = null, prompt $prompt = null)

--- a/classes/reports/realtime/cli.php
+++ b/classes/reports/realtime/cli.php
@@ -39,7 +39,7 @@ class cli extends realtime
 			->addField(new bdd\report\fields\spec\event\fails\failure())
 			->addField(new bdd\report\fields\spec\event\fails\exception())
 			->addField(new bdd\report\fields\spec\event\fails\error())
-			->addField(new bdd\report\fields\spec\event\void())
+			->addField(new bdd\report\fields\spec\event\blank())
 			->addField(new bdd\report\fields\spec\event\skipped())
 		;
 

--- a/specs/units/classes/report/fields/spec/event/blank.php
+++ b/specs/units/classes/report/fields/spec/event/blank.php
@@ -10,7 +10,7 @@ use
 	mageekguy\atoum\bdd\specs
 ;
 
-class void extends specs\units
+class blank extends specs\units
 {
 	public function should_be_a_spec_field()
 	{


### PR DESCRIPTION
void is a reserved keyword with PHP7.1 replace this keyword by blank.

Wait for https://github.com/atoum/atoum/issues/598 before merge
And review by @jubianchi 
